### PR TITLE
Refactor: Status bar appearance, closes #11

### DIFF
--- a/src/components/StatusBar/StatusBar.js
+++ b/src/components/StatusBar/StatusBar.js
@@ -1,109 +1,17 @@
 import React from 'react'
 import ClassNames from 'classnames'
-import _isEmpty from 'lodash/isEmpty'
 import NavbarButton from '../NavbarButton'
 import MANIFEST from '../../../package.json'
-import Input from '../../ui/Input'
-import Button from '../../ui/Button'
-import { COMPONENT_TYPES } from '../GridLayout/GridLayout.helpers'
 import { propTypes, defaultProps } from './StatusBar.props'
 import './style.css'
-
-// NOTE: Temporary until relevant logic is moved into LayoutControlToolbar
-// This just force disables the layout controls regardless of props; all logic
-// implementing the controls must be moved from this component
-const LAYOUT_CONTROLS_ENABLED = false
 
 export default class StatusBar extends React.Component {
   static propTypes = propTypes
   static defaultProps = defaultProps
 
-  state = {
-    componentListOpen: false,
-    layoutListOpen: false,
-    layoutCreatorOpen: false,
-    newLayoutName: '',
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.onToggleComponentList = this.onToggleComponentList.bind(this)
-    this.onToggleLayoutList = this.onToggleLayoutList.bind(this)
-    this.onToggleLayoutCreator = this.onToggleLayoutCreator.bind(this)
-    this.onChangeNewLayoutName = this.onChangeNewLayoutName.bind(this)
-    this.onCreateNewLayout = this.onCreateNewLayout.bind(this)
-    this.onDeleteLayout = this.onDeleteLayout.bind(this)
-    this.onChangeLayout = this.onChangeLayout.bind(this)
-  }
-
-  onToggleComponentList() {
-    this.setState(({ componentListOpen }) => ({
-      componentListOpen: !componentListOpen,
-      layoutListOpen: false,
-      layoutCreatorOpen: false,
-    }))
-  }
-
-  onToggleLayoutList() {
-    this.setState(({ layoutListOpen }) => ({
-      layoutListOpen: !layoutListOpen,
-      componentListOpen: false,
-      layoutCreatorOpen: false,
-    }))
-  }
-
-  onToggleLayoutCreator() {
-    this.setState(({ layoutCreatorOpen }) => ({
-      layoutCreatorOpen: !layoutCreatorOpen,
-      layoutListOpen: false,
-      componentListOpen: false,
-      newLayoutName: '',
-    }))
-  }
-
-  onChangeNewLayoutName(newLayoutName) {
-    this.setState(() => ({ newLayoutName }))
-  }
-
-  onSelectComponent(component) {
-    const { onAddComponentToLayout } = this.props
-
-    onAddComponentToLayout(component)
-
-    this.setState(() => ({ componentListOpen: false }))
-  }
-
-  onCreateNewLayout() {
-    const { newLayoutName } = this.state
-    const { onCreateNewLayout } = this.props
-
-    onCreateNewLayout(newLayoutName)
-
-    this.setState(() => ({ layoutCreatorOpen: false }))
-  }
-
-  onChangeLayout(id) {
-    const { onChangeLayout } = this.props
-    onChangeLayout(id)
-
-    this.setState(() => ({ layoutListOpen: false }))
-  }
-
-  onDeleteLayout(id) {
-    const { onDeleteLayout } = this.props
-    onDeleteLayout(id)
-  }
-
   render() {
     const {
-      layoutListOpen, componentListOpen, newLayoutName, layoutCreatorOpen,
-    } = this.state
-
-    const {
-      onSaveLayout, layoutDirty, displayLayoutControls, layoutName,
-      layoutNames, wsConnected, allowTradingComponents, layoutCanDelete,
-      remoteVersion, apiClientStates, currentExchange,
+      wsConnected, remoteVersion, apiClientStates, currentExchange,
     } = this.props
 
     const apiClientState = apiClientStates[currentExchange]
@@ -113,153 +21,49 @@ export default class StatusBar extends React.Component {
 
     return (
       <div className='hfui-statusbar__wrapper'>
-        {LAYOUT_CONTROLS_ENABLED && displayLayoutControls && (
-          <div className='hfui-statusbar__left'>
-            <div className='hfui-statusbar__layout-name'>
-              <p>Layout</p>
-
-              <p
-                className='hfui-statusbar__layout-active-name'
-                onClick={this.onToggleLayoutList}
-              >
-                {layoutName}
-                <i className='fas fa-chevron-up' />
-              </p>
-
-              <i
-                onClick={layoutName === 'Default'
-                  ? () => {}
-                  : () => this.onDeleteLayout(layoutName)
-                }
-
-                className={ClassNames('fas fa-trash-alt', {
-                  disabled: !layoutCanDelete,
-                })}
+        <div className='hfui-statusbar__left'>
+          <p>
+            {remoteVersion && remoteVersion !== MANIFEST.version ? (
+              <NavbarButton
+                label='Update to latest version'
+                external='https://github.com/bitfinexcom/bfx-hf-ui/releases'
               />
+            ) : null}
+            &nbsp;
+            v
+            {MANIFEST.version}
+          </p>
 
-              <i
-                onClick={onSaveLayout}
-                className={ClassNames('far fa-save', {
-                  yellow: layoutDirty,
-                })}
-              />
-
-              {layoutListOpen && (
-                <ul className='hfui-statusbar__popuplist-wrapper'>
-                  {layoutNames.map(name => (
-                    <li
-                      key={name}
-                      onClick={() => this.onChangeLayout(name)}
-                      className={ClassNames({
-                        yellow: name === layoutName,
-                        selected: name === layoutName,
-                      })}
-                    >
-                      {name}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-
-            <div className='icon with-popuplist'>
-              <p
-                onClick={this.onToggleLayoutCreator}
-              >
-Add Layout
-                <i className='fas fa-plus' />
-              </p>
-
-              {layoutCreatorOpen && (
-                <ul className='hfui-statusbar__popuplist-wrapper form'>
-                  <li className='nohover'>
-                    <Input
-                      type='text'
-                      placeholder='Layout Name'
-                      onChange={this.onChangeNewLayoutName}
-                      value={newLayoutName}
-                    />
-                  </li>
-                  <li className='nohover center'>
-                    <Button
-                      label='Create'
-                      onClick={this.onCreateNewLayout}
-                      disabled={_isEmpty(newLayoutName)}
-                      green
-                    />
-                  </li>
-                </ul>
-              )}
-            </div>
-
-            <div className='icon with-popuplist'>
-              <p
-                onClick={this.onToggleComponentList}
-                className={ClassNames({
-                  yellow: componentListOpen,
-                })}
-              >
-Add Component
-                <i className='fas fa-plus' />
-              </p>
-
-              {componentListOpen && (
-                <ul className='hfui-statusbar__popuplist-wrapper'>
-                  <li onClick={this.onSelectComponent.bind(this, COMPONENT_TYPES.CHART)}>Chart</li>
-                  <li onClick={this.onSelectComponent.bind(this, COMPONENT_TYPES.ORDER_BOOK)}>Order Book</li>
-                  <li onClick={this.onSelectComponent.bind(this, COMPONENT_TYPES.TRADES_TABLE)}>Trades Table</li>
-                  {allowTradingComponents && (<li onClick={this.onSelectComponent.bind(this, COMPONENT_TYPES.TRADING_STATE_PANEL)}>Trading State</li>)}
-                  {allowTradingComponents && (<li onClick={this.onSelectComponent.bind(this, COMPONENT_TYPES.ORDER_FORM)}>Order Form</li>)}
-                </ul>
-              )}
-            </div>
-          </div>
-        )}
+          <p>
+            {apiClientConnected
+              ? `UNLOCKED FOR ${currentExchange.toUpperCase()}`
+              : 'LOCKED'}
+          </p>
+        </div>
 
         <div className='hfui-statusbar__right'>
-          <div
-            className='hfui-statusbar__version'
-          >
-            <p>
-              {remoteVersion && remoteVersion !== MANIFEST.version ? (
-                <NavbarButton
-                  label='Update to latest version'
-                  external='https://github.com/bitfinexcom/bfx-hf-ui/releases'
-                />
-              ) : null}
-              &nbsp;
-              v
-              {MANIFEST.version}
-            </p>
-          </div>
-          <div className='hfui-statusbar__connection-status'>
-            <div className='hfui-statusbar__connection' key='lockstatus'>
-              <p>{apiClientConnected ? `UNLOCKED FOR ${currentExchange.toUpperCase()}` : 'LOCKED'}</p>
-            </div>
-            <div className='hfui-statusbar__connection-status' key='connectionstatus'>
-              <span className={ClassNames('hfui-statusbar__statuscircle', {
-                green: apiClientConnected,
-                yellow: apiClientConnecting,
-                red: apiClientDisconnected,
-              })}
-              />
+          <p>
+            {apiClientConnected
+              ? 'HF Connected'
+              : apiClientConnecting
+                ? 'HF Connecting'
+                : 'HF Disconnected'}
+          </p>
 
-              <p>
-                {apiClientConnected
-                  ? 'HF Connected'
-                  : apiClientConnecting
-                    ? 'HF Connecting'
-                    : 'HF Disconnected'
-              }
-              </p>
-            </div>
-            <p>{wsConnected ? 'WS Connected' : 'WS Disconnected'}</p>
-            <span className={ClassNames('hfui-statusbar__statuscircle', {
-              green: wsConnected,
-              red: !wsConnected,
-            })}
-            />
-          </div>
+          <span className={ClassNames('hfui-statusbar__statuscircle', {
+            green: apiClientConnected,
+            yellow: apiClientConnecting,
+            red: apiClientDisconnected,
+          })}
+          />
+
+          <p>{wsConnected ? 'WS Connected' : 'WS Disconnected'}</p>
+
+          <span className={ClassNames('hfui-statusbar__statuscircle', {
+            green: wsConnected,
+            red: !wsConnected,
+          })}
+          />
         </div>
       </div>
     )

--- a/src/components/StatusBar/StatusBar.props.js
+++ b/src/components/StatusBar/StatusBar.props.js
@@ -1,19 +1,10 @@
 import PropTypes from 'prop-types'
 
 export const propTypes = {
-  onAddComponentToLayout: PropTypes.func,
-  onCreateNewLayout: PropTypes.func,
-  onChangeLayout: PropTypes.func,
-  onDeleteLayout: PropTypes.func,
-  onSaveLayout: PropTypes.func,
-  displayLayoutControls: PropTypes.bool,
-  layoutName: PropTypes.string,
-  layoutNames: PropTypes.array,
-  allowTradingComponents: PropTypes.bool,
   wsConnected: PropTypes.bool,
-  layoutCanDelete: PropTypes.bool,
+  remoteVersion: PropTypes.string,
+  apiClientStates: PropTypes.object,
+  currentExchange: PropTypes.string,
 }
 
-export const defaultProps = {
-  displayLayoutControls: true,
-}
+export const defaultProps = {}

--- a/src/components/StatusBar/style.scss
+++ b/src/components/StatusBar/style.scss
@@ -18,91 +18,21 @@
   user-select: none;
 }
 
-.hfui-statusbar__layout-name {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: row;
-  position: relative;
-
-  p {
-    margin: 0 !important;
-  }
-
-  > i {
-    &:last-child {
-      margin-right: 16px !important;
-    }
-
-    &.disabled {
-      opacity: 0.5;
-    }
-
-    &:hover:not(.disabled) {
-      color: #fcd206;
-      cursor: pointer;
-    }
-  }
-
-  .hfui-statusbar__layout-active-name {
-    text-align: center;
-    width: 100%;
-    padding: 0 8px;
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-
-      &, i {
-        color: #fcd206;
-      }
-    }
-
-    i {
-      margin-left: 8px;
-    }
-  }
-}
-
 .hfui-statusbar__left {
   display: flex;
   flex-direction: row;
   padding-left: 16px;
   flex-shrink: 0;
 
-  p, i, .icon {
+  p {
     line-height: 32px;
   }
 
-  .icon {
-    position: relative;
-    flex-shrink: 0;
-
-    p > i {
-      margin-left: 8px;
-    }
-
-    &.with-popuplist {
-      margin-right: 16px;
-    }
-  }
-
-  .yellow {
-    color: #fcd206;
-  }
-
-  i, .icon {
-    margin-right: 8px;
+  > * {
+    margin-right: 10px;
 
     &:last-child {
       margin-right: 0;
-    }
-
-    &:hover:not(.disabled) {
-      cursor: pointer;
-
-      > p, i {
-        color: #fcd206;
-      }
     }
   }
 }
@@ -112,12 +42,9 @@
   text-align: right;
   padding-right: 16px;
 
-  p {
+  p, span {
     line-height: 32px;
-  }
-
-  span {
-    line-height: 24px;
+    display: inline-block;
   }
 
   & > *, .hfui-statusbar__connection-status > * {
@@ -140,70 +67,12 @@
   &.red {
     background: #F05359;
   }
-}
 
-.hfui-statusbar__popuplist-wrapper {
-  position: absolute;
-  bottom: 32px;
-  left: 0;
-  background: #0d101f;
-  width: 200px;
-  border: 0.5px solid #282e58;
-  border-bottom: none;
-  user-select: none;
-
-  &.form li {
-    margin-bottom: 8px;
-
-    &:first-child {
-      margin-top: 16px;
-    }
-  }
-
-  li {
-    display: block;
-    line-height: 24px;
-    padding: 0 16px;
-    margin-left: 1px;
-
-    &:hover:not(.selected):not(.nohover) {
-      background: rgba(0, 0, 0, 0.3);
-      text-decoration: underline;
-      cursor: pointer;
-    }
-
-    &.center {
-      text-align: center;
-    }
-
-    &.selected {
-      background: rgba(0, 0, 0, 0.3);
-    }
+  &.yellow {
+    background: #f0ed53;
   }
 }
 
 .hfui-statusbar__version {
   line-height: 32px;
-}
-
-.hfui-statusbar__legal {
-  font-size: 11px;
-  margin-right: 16px !important;
-  padding-right: 16px;
-  border-right: 1px solid #333;
-
-  > * {
-    display: inline-block;
-    vertical-align: middle;
-    margin-right: 8px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-    }
-  }
 }


### PR DESCRIPTION
Moves the version string and locked/unlocked status to the left of the sidebar, and normalizes label/status circle order on the right side. Specifically:

Left
![Screenshot from 2020-02-12 16 52 58](https://user-images.githubusercontent.com/1319812/74323492-2b0fd300-4db8-11ea-8839-0fd5da772955.png)


Right
![Screenshot from 2020-02-12 16 53 04](https://user-images.githubusercontent.com/1319812/74323505-3105b400-4db8-11ea-8569-140693496f72.png)

Closes #11 